### PR TITLE
Fix hardware media keys not working on Windows

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -19,6 +19,10 @@ fn main() {
     // Some dev setups enable WebView2 "Visual Diagnostics" via environment variables,
     // which shows an annoying size/diagnostics label overlay in the top-left.
     // Ensure the app never inherits that overlay.
-    std::env::remove_var("WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS");
+    // We also disable HardwareMediaKeyHandling so that our Rust backend can handle media keys via SMTC.
+    std::env::set_var(
+        "WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS",
+        "--disable-features=HardwareMediaKeyHandling",
+    );
     just_another_music_client_lib::run()
 }


### PR DESCRIPTION
Hardware media keys (like headphone buttons) were not working on Windows because Chromium's MediaSession service was intercepting the events and dropping them. I've added `--disable-features=HardwareMediaKeyHandling` to WebView2 arguments in `main.rs` so the native Rust SMTC implementation in `windows_media.rs` can capture and handle them properly.